### PR TITLE
temporarily add netCDF4 to travis build

### DIFF
--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -3,6 +3,7 @@ dependencies:
   - numpy==1.9.3
   - cython
   - pytest
+  - netcdf4
   - pip:
     - coveralls
     - pytest-cov


### PR DESCRIPTION
travis tests are now passing.  Next step, will be to remove (or at least isolate) the netCDF4 dependency.