### PR TITLE
AppVeyor testing using conda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+environment:
+  matrix:
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+platform:
+    - x64
+
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    # The AppVeyor 'rollout builds' option is supposed to serve the same
+    # purpose but it is problematic because it tends to cancel builds pushed
+    # directly to master instead of just PR builds (or the converse).
+    # credits: JuliaLang developers.
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+           throw "There are newer queued builds for this pull request, failing early." }
+
+    # Add path, activate `conda` and update conda.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+    - cmd: conda update conda
+    - cmd: conda config --add channels conda-forge --force
+
+    - cmd: set PYTHONUNBUFFERED=1
+
+    - cmd: conda install conda-build vs2008_express_vc_python_patch
+    - cmd: call setup_x64
+    - cmd: conda info --all
+    - cmd: conda list
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - conda build conda.recipe

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "dev" %}
+
+package:
+  name: netcdftime
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed  --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cython
+    - numpy x.x
+  run:
+    - python
+    - setuptools
+    - numpy x.x
+
+test:
+  source_files:
+    - test
+  requires:
+    - pytest
+  imports:
+    - netcdftime
+  commands:
+    - py.test -vv test
+
+about:
+  home: https://github.com/Unidata/netcdftime
+  license: OSI Approved
+  summary: 'Provides an object-oriented python interface to the netCDF version 4 library..'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup
+from setuptools import setup
 from Cython.Build import cythonize
 
 
@@ -19,16 +19,20 @@ def extract_version(module='netcdftime'):
 
 
 with open('requirements.txt') as f:
-    tests_require = f.readlines()
-install_requires = [t.strip() for t in tests_require]
+    reqs = f.readlines()
+install_requires = [req.strip() for req in reqs]
+
+with open('requirements-dev.txt') as f:
+    reqs = f.readlines()
+tests_require = [req.strip() for req in reqs]
 
 setup(
     name='netcdftime',
-    author='Jeff Whit',
-    author_email='lapok@atmos.washington.edu',
+    author='Jeff Whitaker',
+    author_email='jeffrey.s.whitaker@noaa.gov',
     description='Time-handling functionality from netcdf4-python',
     packages=['netcdftime'],
     version=extract_version(),
     ext_modules=cythonize('netcdftime/*.pyx'),
     install_requires=install_requires,
-    tests_require=['pytest'])
+    tests_require=tests_require)


### PR DESCRIPTION
This test uses `conda-build` to manage the `cython` compilation and dependencies. The tests are run for `Python 2.7`, `3.6` and `numpy 1.12`, `1.13`.

@jhamman someone with the proper rights to this repo must activate AppVeyor. Here are the results from my instance: https://ci.appveyor.com/project/ocefpaf/netcdftime