### PR TITLE
fix for issue #17

### DIFF
--- a/netcdftime/_netcdftime.pyx
+++ b/netcdftime/_netcdftime.pyx
@@ -31,12 +31,16 @@ _calendars = ['standard', 'gregorian', 'proleptic_gregorian',
 __version__ = '1.4.1'
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
+# Note: This regex ensures that all ISO8601 timezone formats are accepted - but, due to legacy support for other timestrings, not all incorrect formats can be rejected.
+#       For example, the TZ spec "+01:0" will still work even though the minutes value is only one character long.
 ISO8601_REGEX = re.compile(r"(?P<year>[+-]?[0-9]{1,4})(-(?P<month>[0-9]{1,2})(-(?P<day>[0-9]{1,2})"
                            r"(((?P<separator1>.)(?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{1,2})(:(?P<second>[0-9]{1,2})(\.(?P<fraction>[0-9]+))?)?)?"
-                           r"((?P<separator2>.?)(?P<timezone>Z|(([-+])([0-9]{1,2}):([0-9]{1,2}))))?)?)?)?"
+                           r"((?P<separator2>.?)(?P<timezone>Z|(([-+])([0-9]{2})((:([0-9]{2}))|([0-9]{2}))?)))?)?)?)?"
                            )
+# Note: The re module apparently does not support branch reset groups that allow redifinition of the same group name in alternative branches as PCRE does.
+#       Using two different group names is also somewhat ugly, but other solutions might hugely inflate the expression. feel free to contribute a better solution.
 TIMEZONE_REGEX = re.compile(
-    "(?P<prefix>[+-])(?P<hours>[0-9]{1,2}):(?P<minutes>[0-9]{1,2})")
+    "(?P<prefix>[+-])(?P<hours>[0-9]{2})(?:(?::(?P<minutes1>[0-9]{2}))|(?P<minutes2>[0-9]{2}))?")  
 
 
 # start of the gregorian calendar
@@ -1191,8 +1195,11 @@ cdef _parse_timezone(tzstring):
     if tzstring is None:
         return 0
     m = TIMEZONE_REGEX.match(tzstring)
-    prefix, hours, minutes = m.groups()
-    hours, minutes = int(hours), int(minutes)
+    prefix, hours, minutes1, minutes2 = m.groups()
+    hours = int(hours)
+    # Note: Minutes don't have to be specified in tzstring, so if the group is not found it means minutes is 0.
+    #       Also, due to the timezone regex definition, there are two mutually exclusive groups that might hold the minutes value, so check both.
+    minutes = int(minutes1) if minutes1 is not None else int(minutes2) if minutes2 is not None else 0
     if prefix == "-":
         hours = -hours
         minutes = -minutes

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -947,17 +947,23 @@ class issue17TestCase(unittest.TestCase):
     def test_parse_date_tz(self):
         "Test timezone parsing in _parse_date"
 
-        # these should succeed
+        # these should succeed and are ISO8601 compliant
         expected_parsed_date = (2017, 5, 1, 0, 0, 0, 60.0)
         for datestr in ("2017-05-01 00:00+01:00", "2017-05-01 00:00+0100", "2017-05-01 00:00+01"):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
-        # these should fail/not be recognized as timezone modifiers
-        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 0.0)
-        for datestr in ("2017-05-01 00:00+1:0", "2017-05-01 00:00+1", "2017-05-01 00:00+01:0", "2017-05-01 00:00+01:"):
+        # these are NOT ISO8601 compliant and should not even be parseable but will be parsed with timezone anyway
+        # because, due to support of other legacy time formats, they are difficult to reject
+        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 60.0)
+        for datestr in ("2017-05-01 00:00+01:0", "2017-05-01 00:00+01:"):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
-            
+        # these should not even be parseable as datestrings but are parseable anyway with ignored timezone
+        # this is because the module also supports some legacy, non-standard time strings
+        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 0.0)
+        for datestr in ("2017-05-01 00:00+1",):
+            d = _parse_date(datestr)
+            assert_equal(d, expected_parsed_date)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -476,7 +476,6 @@ class netcdftimeTestCase(unittest.TestCase):
         d = num2date(0, units, calendar='360_day')
         self.assertEqual(d, Datetime360Day(0,1,1))
 
-
         # list around missing dates in Gregorian calendar
         # scalar
         units = 'days since 0001-01-01 12:00:00'

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -11,7 +11,7 @@ from netcdftime import (utime, JulianDayFromDate, DateFromJulianDay,
                         DatetimeNoLeap, DatetimeAllLeap, Datetime360Day,
                         DatetimeJulian, DatetimeGregorian,
                         DatetimeProlepticGregorian)
-from netcdftime import num2date, date2num, date2index
+from netcdftime import num2date, date2num, date2index, _parse_date
 
 
 # test netcdftime module for netCDF time <--> python datetime conversions.
@@ -476,6 +476,7 @@ class netcdftimeTestCase(unittest.TestCase):
         d = num2date(0, units, calendar='360_day')
         self.assertEqual(d, Datetime360Day(0,1,1))
 
+
         # list around missing dates in Gregorian calendar
         # scalar
         units = 'days since 0001-01-01 12:00:00'
@@ -933,6 +934,31 @@ class DateTime(unittest.TestCase):
 
         for func in [not_comparable_1, not_comparable_2, not_comparable_3, not_comparable_4]:
             self.assertRaises(TypeError, func)
+        
+
+
+class issue17TestCase(unittest.TestCase):
+    """Regression tests for issue #17/#669."""
+    # issue 17 / 699: timezone formats not supported correctly
+    # valid timezone formats are: +-hh, +-hh:mm, +-hhmm
+
+    def setUp(self):
+        pass
+
+    def test_parse_date_tz(self):
+        "Test timezone parsing in _parse_date"
+
+        # these should succeed
+        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 60.0)
+        for datestr in ("2017-05-01 00:00+01:00", "2017-05-01 00:00+0100", "2017-05-01 00:00+01"):
+            d = _parse_date(datestr)
+            assert_equal(d, expected_parsed_date)
+        # these should fail/not be recognized as timezone modifiers
+        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 0.0)
+        for datestr in ("2017-05-01 00:00+1:0", "2017-05-01 00:00+1", "2017-05-01 00:00+01:0"):
+            d = _parse_date(datestr)
+            assert_equal(d, expected_parsed_date)
+            
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -954,7 +954,7 @@ class issue17TestCase(unittest.TestCase):
             assert_equal(d, expected_parsed_date)
         # these should fail/not be recognized as timezone modifiers
         expected_parsed_date = (2017, 5, 1, 0, 0, 0, 0.0)
-        for datestr in ("2017-05-01 00:00+1:0", "2017-05-01 00:00+1", "2017-05-01 00:00+01:0"):
+        for datestr in ("2017-05-01 00:00+1:0", "2017-05-01 00:00+1", "2017-05-01 00:00+01:0", "2017-05-01 00:00+01:"):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
             

--- a/test/test_netcdftime.py
+++ b/test/test_netcdftime.py
@@ -952,10 +952,16 @@ class issue17TestCase(unittest.TestCase):
         for datestr in ("2017-05-01 00:00+01:00", "2017-05-01 00:00+0100", "2017-05-01 00:00+01"):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
+        # some more tests with non-zero minutes, should all be ISO compliant and work
+        expected_parsed_date = (2017, 5, 1, 0, 0, 0, 85.0)
+        for datestr in ("2017-05-01 00:00+01:25", "2017-05-01 00:00+0125"):
+            d = _parse_date(datestr)
+            assert_equal(d, expected_parsed_date)
         # these are NOT ISO8601 compliant and should not even be parseable but will be parsed with timezone anyway
         # because, due to support of other legacy time formats, they are difficult to reject
+        # ATTENTION: only the hours part of this will be parsed, single-digit minutes will be ignored!
         expected_parsed_date = (2017, 5, 1, 0, 0, 0, 60.0)
-        for datestr in ("2017-05-01 00:00+01:0", "2017-05-01 00:00+01:"):
+        for datestr in ("2017-05-01 00:00+01:0", "2017-05-01 00:00+01:", "2017-05-01 00:00+01:5"):
             d = _parse_date(datestr)
             assert_equal(d, expected_parsed_date)
         # these should not even be parseable as datestrings but are parseable anyway with ignored timezone


### PR DESCRIPTION
Not as clean as I would like it to be because some ancient non-standard time strings have to be supported. Improvements welcome!